### PR TITLE
Create Linux x64 asset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,6 +88,7 @@ jobs:
           generate_release_notes: true
           files: |
             dist/turndown-cli-linux-arm64
+            dist/turndown-cli-linux-x64
             dist/turndown-cli-macos-arm64
             dist/turndown-cli-macos-x64
             dist/SHA256SUMS

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,7 @@ npm run pkg
 
 Creates standalone executables in `dist/` for:
 - node18-linux-arm64
+- node18-linux-x64
 - node18-macos-x64
 - node18-macos-arm64
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "pkg": {
     "targets": [
       "node18-linux-arm64",
+      "node18-linux-x64",
       "node18-macos-x64",
       "node18-macos-arm64"
     ],


### PR DESCRIPTION
This pull request adds support for building and releasing a new `linux-x64` standalone executable for the project. The changes ensure that the new binary is included in the build process, documentation, and release workflow.

Build and release process updates:

* Added `node18-linux-x64` to the list of build targets in `package.json`, so the `linux-x64` binary will be generated during the packaging step.
* Updated the GitHub Actions release workflow (`.github/workflows/release.yml`) to include the new `dist/turndown-cli-linux-x64` binary in release artifacts.

Documentation update:

* Updated `CLAUDE.md` to document that a `node18-linux-x64` standalone executable is now created.