### PR TITLE
Improve Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
           MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_CI_KEYCHAIN_PWD }}
         run: |
           # Turn our base64-encoded certificate back to a regular .p12 file
-          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          echo "$MACOS_CERTIFICATE" | base64 --decode > certificate.p12
 
           # We need to create a new keychain, otherwise using the certificate will prompt
           # with a UI dialog asking for the certificate password, which we can't

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,9 +64,11 @@ jobs:
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" dist/turndown-cli-macos-arm64 -v
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" dist/turndown-cli-macos-x64 -v
 
-          # Clean up sensitive files
+      - name: Cleanup certificates
+        if: always()
+        run: |
           rm -f certificate.p12
-          security delete-keychain build.keychain
+          security delete-keychain build.keychain || true
 
       - name: Verify executables
         run: |


### PR DESCRIPTION
This pull request makes minor improvements to the macOS release workflow to ensure better handling of environment variables and more robust cleanup of sensitive files.

- **Workflow improvements in `.github/workflows/release.yml`:**
  - Quoted the `MACOS_CERTIFICATE` environment variable when decoding from base64 to handle special characters or whitespace correctly.
  - Updated the cleanup step to always run, renamed it to "Cleanup certificates," and made the keychain deletion command resilient to errors by appending `|| true`.