### PR TITLE
Fix Building Linux on Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,14 +1,13 @@
 name: Release
+
 on:
   push:
     tags:
       - '[0-9]+.[0-9]+.[0-9]+'
 
 jobs:
-  release:
+  build-macos:
     runs-on: macos-latest-xlarge
-    permissions:
-      contents: write
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -28,8 +27,8 @@ jobs:
       - name: Build
         run: npm run build
 
-      - name: Package
-        run: npm run pkg
+      - name: Package macOS binaries
+        run: npx pkg . --out-path dist --targets node18-macos-x64,node18-macos-arm64
 
       # https://federicoterzi.com/blog/automatic-code-signing-and-notarization-for-macos-apps-using-github-actions/
       - name: Codesign
@@ -52,10 +51,6 @@ jobs:
           echo "Importing certificate..."
           security import certificate.p12 -k build.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
 
-          # Debugging
-          echo "Find identity..."
-          security find-identity -v
-
           echo "Set key partition list..."
           security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" build.keychain
 
@@ -70,17 +65,82 @@ jobs:
           rm -f certificate.p12
           security delete-keychain build.keychain || true
 
-      - name: Verify executables
+      - name: Verify macOS executables
         run: |
           ./dist/turndown-cli-macos-arm64 --version
           ./dist/turndown-cli-macos-x64 --version
           # Test basic conversion
           echo "<h1>Test</h1>" | ./dist/turndown-cli-macos-arm64
 
+      - name: Upload macOS artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: macos-binaries
+          path: |
+            dist/turndown-cli-macos-arm64
+            dist/turndown-cli-macos-x64
+          retention-days: 1
+
+  build-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 18
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build
+        run: npm run build
+
+      - name: Package Linux binaries
+        run: npx pkg . --out-path dist --targets node18-linux-arm64,node18-linux-x64
+
+      - name: Verify Linux x64 executable
+        run: |
+          ./dist/turndown-cli-linux-x64 --version
+          echo "<h1>Test</h1>" | ./dist/turndown-cli-linux-x64
+
+      - name: Upload Linux artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: linux-binaries
+          path: |
+            dist/turndown-cli-linux-arm64
+            dist/turndown-cli-linux-x64
+          retention-days: 1
+
+  release:
+    needs: [build-macos, build-linux]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download macOS artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: macos-binaries
+          path: dist
+
+      - name: Download Linux artifacts
+        uses: actions/download-artifact@v6
+        with:
+          name: linux-binaries
+          path: dist
+
       - name: Generate checksums
         run: |
           cd dist
-          shasum -a 256 turndown-cli-* > SHA256SUMS
+          sha256sum turndown-cli-* > SHA256SUMS
 
       - name: Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,6 +59,11 @@ jobs:
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" dist/turndown-cli-macos-arm64 -v
           /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" dist/turndown-cli-macos-x64 -v
 
+      - name: Verify codesign
+        run: |
+          codesign --verify --verbose dist/turndown-cli-macos-arm64
+          codesign --verify --verbose dist/turndown-cli-macos-x64
+
       - name: Cleanup certificates
         if: always()
         run: |
@@ -109,6 +114,7 @@ jobs:
         run: |
           ./dist/turndown-cli-linux-x64 --version
           echo "<h1>Test</h1>" | ./dist/turndown-cli-linux-x64
+          # Note: ARM64 binary cannot be tested on x64 runner without QEMU
 
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v6
@@ -137,9 +143,18 @@ jobs:
           name: linux-binaries
           path: dist
 
+      - name: Verify artifacts
+        run: |
+          ls -lh dist/
+          test -f dist/turndown-cli-macos-arm64
+          test -f dist/turndown-cli-macos-x64
+          test -f dist/turndown-cli-linux-arm64
+          test -f dist/turndown-cli-linux-x64
+
       - name: Generate checksums
         run: |
           cd dist
+          # Generate SHA256 checksums for release verification
           sha256sum turndown-cli-* > SHA256SUMS
 
       - name: Release


### PR DESCRIPTION
This pull request significantly restructures the GitHub Actions release workflow to support building, packaging, and verifying binaries for both macOS and Linux platforms. The workflow is now split into separate jobs for building on each platform, and a final release job that collects artifacts and creates the release. Key improvements include platform-specific packaging, code signing and verification for macOS, and artifact management.

**Workflow Restructuring and Multi-Platform Support:**

* Split the release workflow into three jobs: `build-macos`, `build-linux`, and `release`, enabling parallel and platform-specific builds and tests. (`.github/workflows/release.yml`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R2-L11) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R62-R158)

**macOS Build and Verification Enhancements:**

* Updated the macOS build job to package both arm64 and x64 binaries, added explicit code signing verification, and upload artifacts for later use in the release step. (`.github/workflows/release.yml`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L31-R31) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R62-R158)

**Linux Build and Verification:**

* Introduced a dedicated Linux build job that packages arm64 and x64 binaries, verifies the x64 binary, and uploads artifacts for the release. (`.github/workflows/release.yml`)

**Artifact Management and Release Process:**

* The new `release` job downloads artifacts from build jobs, verifies their presence, generates SHA256 checksums, and publishes the release using `softprops/action-gh-release`. (`.github/workflows/release.yml`)

**Cleanup and Minor Improvements:**

* Removed unnecessary debug steps and improved the checksum generation command for better compatibility. (`.github/workflows/release.yml`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L55-L58) [[2]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R62-R158)